### PR TITLE
Optimize ETL process

### DIFF
--- a/missions/w1/m3/etl_project_gdp.py
+++ b/missions/w1/m3/etl_project_gdp.py
@@ -20,19 +20,34 @@ def extract():
 		data = {'raw_data':html}
 		save_raw_data_with_backup(JSON_FILE, data)
 		logger('extract', 'done')
+		return data
 	except Exception as e:
 		logger('extract', 'ERROR: ' + str(e))
 		raise e
 
+def transform_html_tr_tags(trs: list):
+	tr_dict = {}
+	for tr in trs:
+		cells = tr.find_all('td')  # Get all cells in the row
+		if len(cells) > 1:  # Cell[0] is country name, cell[1] is GDP from IMF
+			if cells[0].text.strip() == 'World': continue
+			tr_dict[cells[0].text.strip()] = cells[1].text.replace(',', '').strip()
+	return tr_dict
+
+def trans_df_column_numeric(df: pd.DataFrame, column: str):
+	df[column] = pd.to_numeric(df[column], errors='coerce').astype('Int64')
+	return df
+
+def merge_region_info_df(df: pd.DataFrame):
+	region_df = pd.read_csv(REGION_CSV_PATH, usecols=['name', 'region'])
+	region_df.rename(columns={'name': 'country'}, inplace=True)
+	return pd.merge(df, region_df, how='left', on='country')  # Join dataframes on country column
+
 # Transform data extracted by web scrapping using beautifulsoup
 # DataFrame columns = GDP, country, region
-def transform(file_name: str = JSON_FILE):
+def transform(data: dict):
 	try:
 		logger('Transform', 'start')
-		data = {}
-		gdp_dict = {}
-		with open(file_name, 'r') as f:
-			data = json.load(f)['data']
 		soup = BeautifulSoup(data['raw_data'], 'html.parser')
 		table_soup = soup.select('table.wikitable') # Find a table with class 'wikitable'
 		if len(table_soup) < 1:
@@ -41,17 +56,11 @@ def transform(file_name: str = JSON_FILE):
 		if len(table_soup) > 1:
 			logger('Transform', 'WARNNING: Multiple tables found')
 		rows = table_soup[0].find_all('tr') # Get all rows in the table
-		for row in rows:
-			cells = row.find_all('td') # Get all cells in the row
-			if len(cells) > 1: # Cell[0] is country name, cell[1] is GDP from IMF
-				if cells[0].text.strip() == 'World': continue
-				gdp_dict[cells[0].text.strip()] = cells[1].text.replace(',', '').strip()
+		gdp_dict = transform_html_tr_tags(rows) # transform tr tags to dict
 		gdp_df = pd.DataFrame(list(gdp_dict.items()), columns=['country', 'GDP'])
-		gdp_df['GDP'] = pd.to_numeric(gdp_df['GDP'], errors='coerce').astype('Int64') # Change datatype as int64
+		gdp_df = trans_df_column_numeric(gdp_df, 'GDP') # Change datatype as int64
 		gdp_df['GDP'] = gdp_df['GDP'] / 1000 # Change as billion unit.
-		region_df = pd.read_csv(REGION_CSV_PATH)
-		region_df = pd.DataFrame({'country' : region_df['name'], 'region':region_df['region']}) # Get region info in csv file
-		merged_gdp_df = pd.merge(gdp_df, region_df, how='left', on='country') # Join dataframes on country column
+		merged_gdp_df = merge_region_info_df(gdp_df)
 		logger('Transform', 'done')
 		return merged_gdp_df
 	except Exception as e:
@@ -71,8 +80,8 @@ def load(df: pd.DataFrame):
 
 if __name__ == '__main__':
 	try:
-		extract()
-		df = transform()
+		data = extract()
+		df = transform(data)
 		load(df)
 		display_info_with_pandas(on_memory_loaded_df)
 	except Exception as e:

--- a/missions/w1/m3/etl_project_gdp.py
+++ b/missions/w1/m3/etl_project_gdp.py
@@ -1,7 +1,6 @@
 from bs4 import BeautifulSoup
 import requests
 import pandas as pd
-import json
 from etl_project_util import save_raw_data_with_backup, display_info_with_pandas, logger
 
 JSON_FILE = 'Countries_by_GDP.json'

--- a/missions/w1/m3/etl_project_gdp_api.py
+++ b/missions/w1/m3/etl_project_gdp_api.py
@@ -36,6 +36,11 @@ def extract(end_points: tuple = ('NGDPD', 'countries')):
 		logger('Extract-API', 'ERROR: ' + str(e))
 		raise e
 
+def join_country_region_df(df: pd.DataFrame, country_df: pd.DataFrame, region_df: pd.DataFrame):
+	df = df.join(country_df, how='left')
+	df = df.join(region_df, how='left')
+	return df
+
 # Transform data extracted with imf api and return dataframe
 # DataFrame columns = GDP, country, region
 def transform(data: dict):
@@ -48,8 +53,7 @@ def transform(data: dict):
 		country_df.rename(columns={'label': 'country'}, inplace=True)
 		# Extract continent info from continent csv
 		region_df = pd.read_csv(CONTINENT_CSV_PATH, usecols=['alpha-3', 'region'], index_col='alpha-3')
-		gdp_df = gdp_df.join(country_df)
-		gdp_df = gdp_df.join(region_df)
+		gdp_df = join_country_region_df(gdp_df, country_df, region_df)
 		transformed_df = gdp_df[['country', '2025', 'region']].copy()
 		transformed_df.rename(columns={'2025': 'GDP'}, inplace=True)
 		transformed_df.dropna(subset=['country'], inplace=True)

--- a/missions/w1/m3/etl_project_gdp_api.py
+++ b/missions/w1/m3/etl_project_gdp_api.py
@@ -31,17 +31,16 @@ def extract(end_points: tuple = ('NGDPD', 'countries')):
 			data[endpoint] = request_get_url(API_BASE_URL, endpoint)
 		save_raw_data_with_backup(JSON_FILE, data)
 		logger('Extract-API', 'done')
+		return data
 	except Exception as e:
 		logger('Extract-API', 'ERROR: ' + str(e))
 		raise e
 
 # Transform data extracted with imf api and return dataframe
 # DataFrame columns = GDP, country, region
-def transform(json_file: str = JSON_FILE):
+def transform(data: dict):
 	try:
 		logger('Transform-API', 'start')
-		with open(json_file, 'r') as f: # get extracted data by json
-			data = json.load(f)['data']
 		# Extract GDP DataFrame index = Country Code, columns = year, value = GDP of year
 		gdp_df = pd.DataFrame(data['NGDPD']['values']['NGDPD']).T
 		# Extract Country DataFrame index = Country Code, columns = label, value = Country string
@@ -78,7 +77,7 @@ def load(df: pd.DataFrame):
 
 if __name__ == '__main__':
 	try:
-		extract()
+		data = extract()
 		df = transform()
 		load(df)
 		display_info_with_pandas(on_memory_loaded_df)

--- a/missions/w1/m3/etl_project_gdp_api.py
+++ b/missions/w1/m3/etl_project_gdp_api.py
@@ -1,4 +1,3 @@
-import json
 import requests
 import pandas as pd
 from etl_project_util import save_raw_data_with_backup, display_info_with_pandas, logger

--- a/missions/w1/m3/etl_project_gdp_api.py
+++ b/missions/w1/m3/etl_project_gdp_api.py
@@ -82,7 +82,7 @@ def load(df: pd.DataFrame):
 if __name__ == '__main__':
 	try:
 		data = extract()
-		df = transform()
+		df = transform(data)
 		load(df)
 		display_info_with_pandas(on_memory_loaded_df)
 	except Exception as e:

--- a/missions/w1/m3/etl_project_gdp_combined.py
+++ b/missions/w1/m3/etl_project_gdp_combined.py
@@ -24,9 +24,10 @@ if __name__ == "__main__":
         transform = etl_project_gdp_api.transform
     df = pd.DataFrame()
     if args.raw_json:
-        df = transform(args.raw_json)
+        data = etl_project_util.read_json_file(args.raw_json)
+        df = transform(data)
     else:
-        extract()
-        df = transform()
+        data = extract()
+        df = transform(data)
     load(df, args.table_name)
     etl_project_util.display_info_with_sqlite(SQL_PATH ,table_name=args.table_name)

--- a/missions/w1/m3/etl_project_gdp_with_sql.py
+++ b/missions/w1/m3/etl_project_gdp_with_sql.py
@@ -18,8 +18,8 @@ def load(df: pd.DataFrame, table_name: str = 'Countries_by_GDP'):
 
 if __name__ == '__main__':
     try:
-        extract()
-        df = transform()
+        data = extract()
+        df = transform(data)
         load(df)
         display_info_with_sqlite(SQL_PATH)
     except Exception as e:

--- a/missions/w1/m3/etl_project_util.py
+++ b/missions/w1/m3/etl_project_util.py
@@ -79,6 +79,16 @@ def save_raw_data_with_backup(file_name, data):
         data_with_meta = {'data': data, 'meta_data': {'date': datetime.now().strftime('%Y-%B-%d %H:%M:%S')}}
         json.dump(data_with_meta, f)
 
+def read_json_file(file_name):
+    try:
+        with open(file_name, 'r') as f:
+            data = json.load(f)
+            print(f'Data Successfully Loaded meta_data:{data['meta_data']}')
+        return data['data']
+    except FileNotFoundError:
+        print(f'File not found: {file_name}')
+        return None
+
 # log etl step with msg
 def logger(step: str, msg: str):
     with open(LOG_FILE, 'a') as file:


### PR DESCRIPTION
1. ETL 프로세스에서 Extract한 raw data를 json 파일로 저장하고, Transform이 json 파일을 읽어와서 transform하는 방식
--> Extract한 raw data를 json 파일로 저장하고, Transform은 이와 별개로, Extract 함수의 리턴값을 받아와서 transform하는 방식으로 변경.
2. Pandas에서 dataframe을 수월하게 병렬처리할 수 있도록, transform 세부 과정을 함수화.
