### PR TITLE
Setup single-node Hadoop environment with Docker

### DIFF
--- a/missions/W3/M1/.gitignore
+++ b/missions/W3/M1/.gitignore
@@ -1,0 +1,2 @@
+*.tar.gz
+volume

--- a/missions/W3/M1/Dockerfile
+++ b/missions/W3/M1/Dockerfile
@@ -1,0 +1,47 @@
+FROM openjdk:8
+
+# 작업 디렉토리 설정
+WORKDIR /hadoop
+
+# 필수 패키지 설치
+RUN apt-get update && apt-get install -y wget tar ssh rsync sudo && \
+    apt-get clean
+
+COPY ./src/hadoop-3.4.1.tar.gz .
+
+RUN tar -xzf hadoop-3.4.1.tar.gz && \
+    mv hadoop-3.4.1 /usr/local/hadoop && \
+    rm hadoop-3.4.1.tar.gz
+
+ENV HADOOP_HOME=/usr/local/hadoop \
+    HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop \
+    PATH=$PATH:/usr/local/hadoop/bin:/usr/local/hadoop/sbin \
+    HDFS_NAMENODE_USER=root \
+    HDFS_DATANODE_USER=root \
+    HDFS_SECONDARYNAMENODE_USER=root \
+    YARN_RESOURCEMANAGER_USER=root \
+    YARN_NODEMANAGER_USER=root
+
+# SSH 설정 (Hadoop의 통신 필요)
+RUN ssh-keygen -q -t rsa -N '' -f ~/.ssh/id_rsa && \
+    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && \
+    chmod 600 ~/.ssh/authorized_keys
+
+# Hadoop 구성 파일 복사
+COPY conf/core-site.xml $HADOOP_CONF_DIR/core-site.xml
+COPY conf/hdfs-site.xml $HADOOP_CONF_DIR/hdfs-site.xml
+COPY conf/mapred-site.xml $HADOOP_CONF_DIR/mapred-site.xml
+
+
+# 네임노드 및 데이터 디렉토리 생성
+RUN mkdir -p /hadoop/dfs/name /hadoop/dfs/data
+
+RUN echo "export JAVA_HOME=$JAVA_HOME" >> /usr/local/hadoop/etc/hadoop/hadoop-env.sh
+
+# 포트 오픈 (NameNode, DataNode, ResourceManager 등)
+EXPOSE 9870 8088 9000 9864 22
+
+COPY src/init.sh .
+RUN chmod +x init.sh
+
+ENTRYPOINT ["./init.sh"]

--- a/missions/W3/M1/conf/core-site.xml
+++ b/missions/W3/M1/conf/core-site.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <!-- HDFS의 기본 파일 시스템 주소 -->
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://0.0.0.0:9000</value>
+    </property>
+    <property>
+        <name>dfs.client.use.datanode.hostname</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>dfs.datanode.hostname</name>
+        <value>localhost</value>
+    </property>
+</configuration>

--- a/missions/W3/M1/conf/hdfs-site.xml
+++ b/missions/W3/M1/conf/hdfs-site.xml
@@ -1,0 +1,35 @@
+<configuration>
+    <!-- 블록 복제본 수 (단일 노드에서는 1로 설정) -->
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+
+    <!-- 네임노드 데이터 저장 디렉토리 -->
+    <property>
+        <name>dfs.namenode.name.dir</name>
+        <value>file:///hadoop/dfs/name</value>
+    </property>
+
+    <!-- 데이터노드 데이터 저장 디렉토리 -->
+    <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>file:///hadoop/dfs/data</value>
+    </property>
+    <property>
+        <name>dfs.webhdfs.enabled</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>dfs.namenode.http-address</name>
+        <value>0.0.0.0:9870</value>
+    </property>
+    <property>
+        <name>dfs.datanode.http.address</name>
+        <value>0.0.0.0:9864</value>
+    </property>
+    <property>
+        <name>dfs.permissions.enabled</name>
+        <value>false</value>
+    </property>
+</configuration>

--- a/missions/W3/M1/conf/mapred-site.xml
+++ b/missions/W3/M1/conf/mapred-site.xml
@@ -1,0 +1,7 @@
+<configuration>
+    <!-- MapReduce 실행 프레임워크 설정 -->
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/missions/W3/M1/docker-compose.yml
+++ b/missions/W3/M1/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  hadoop:
+    build:
+      context: .  # 현재 디렉토리에서 Dockerfile을 가져옴
+    container_name: hadoop-container  # 컨테이너 이름
+    ports:
+      - "9870:9870"  # NameNode UI 포트
+      - "9864:9864"  # DataNode UI 포트
+      - "9000:9000"  # HDFS 포트
+      - "8088:8088"  # ResourceManager 포트
+      - "22:22"      # SSH 포트
+    volumes:
+      - ./volume/dfs/name:/hadoop/dfs/name  # 호스트와 컨테이너 볼륨 연결
+      - ./volume/dfs/data:/hadoop/dfs/data  # 호스트와 컨테이너 볼륨 연결
+    restart: always  # 컨테이너가 중지될 경우 자동 재시작

--- a/missions/W3/M1/src/init.sh
+++ b/missions/W3/M1/src/init.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+service ssh start
+
+# NameNode 포맷 (최초 실행 시에만)
+if [ ! -d "/hadoop/dfs/name" ] || [ -z "$(ls -A /hadoop/dfs/name)" ]; then
+    echo "Formatting NameNode..."
+    $HADOOP_HOME/bin/hdfs namenode -format -force
+else
+    echo "NameNode already formatted. Skipping format."
+fi
+
+# HDFS 시작
+$HADOOP_HOME/sbin/start-dfs.sh
+
+# 포그라운드 유지 및 로그 출력
+tail -f $HADOOP_HOME/logs/*.log


### PR DESCRIPTION
Added configuration files, Dockerfile, and a docker-compose.yml to create a single-node Hadoop setup using Docker. Included HDFS, MapReduce, and core configurations, along with initialization scripts and volume mappings for persistent data storage.