### PR TITLE
Add daily retrospective for 2025.01.29

### DIFF
--- a/DailyRetrospective/w4/25_01_29.md
+++ b/DailyRetrospective/w4/25_01_29.md
@@ -1,0 +1,59 @@
+# 데일리 리뷰
+
+날짜: 2025년 1월 29일
+작성자: 최민제
+
+# ✏️ Review
+
+## Spark를 py.pi를 통해 이해해보기
+
+1. `sc = SparkContext(appName=<appname>)`
+
+    SparkContext를 생성한다.
+
+    SparkContext는 이후에 Workernode에 대한 관리를 진행한다.
+
+2. `rdd = sc.parallelize(data)`
+
+    parallelize를 통해서 RDD를 생성할 수 있다.
+
+    data를 여러개의 파티션으로 나누고, 이를 이후에 executor에 분배하여 병렬 실행한다.
+
+    ### RDD (Resilient Distributed Dataset)
+
+    - `sc.parallelize()`
+
+        `parallelize()` 를 통해서 파이썬 리스트와 같은 기본 데이터를 RDD로 변환한다.
+
+    - `sc.textFile()`
+
+        HDFS, S3, 로컬 파일 시스템 등… 다양한 소스에서 텍스트 파일을 읽어와서 RDD를 생성한다.
+
+
+## Spark interactive mode로 사용하기
+
+- Spark를 사용하여서 뉴욕 택시 데이터를 가공하기 위해서는, interactive하게 택시 데이터들의 field에 접근하여 여러가지 spark pandas API들을 사용해봐야 되었다.
+- 이를 위해서 interactive mode로 연결하여서 직접 테스트를 진행하였다.
+- 방법은 아래와 같다
+    - `pyspark --master spark://localhost:7077`
+
+        위 주소로 docker container를 올린 host에서 접근한다.
+
+        이때, container를 올린 호스트 머신에는 pyspark를 미리 설치하여야 된다.
+
+        위와 같은 방식을 client 모드라고 할 수 있다.
+
+        이때, spark가 현재 standalone 모드로, yarn과 같은 외부 resource manager가 아닌 spark가 직접 resource를 관리하고 있기에, `spark://` 를 통해서 접근하였다.
+
+        포트의 경우, 현재 master 노드의 7077 포트가 host 머신의 7077 포트와 바인딩 되어있기 때문에, `localhost:7077`로 접근이 가능해진다.
+
+
+# 🤔 Retrospective
+
+## ⚠️ Problem
+
+## 🌟 Keep
+
+- 생산성을 높이기 위해서 한번 코드를 작성하고 전체를 계속해서 실행하는 방식을 버리고, sparkshell을 통해서 interactive하게 개발을 진행할 수 있었다.
+
+## 💡 Try

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ### W4
 #### 개인 회고
 * [2025.01.28](https://github.com/minjacho42/HMG_5th/blob/master/DailyRetrospective/w4/25_01_28.md)
+* [2025.01.29](https://github.com/minjacho42/HMG_5th/blob/master/DailyRetrospective/w4/25_01_29.md)
 
 ## INDEX
 


### PR DESCRIPTION
Created a detailed daily retrospective document for January 29, 2025, including insights on working with Spark and interactive development approaches. Updated the README to include a link to the new entry for easy navigation.